### PR TITLE
fix: define client-side env and bun preset on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ COPY . .
 ENV NODE_ENV=production
 ARG VITE_APP_NAME
 ENV VITE_APP_NAME=${VITE_APP_NAME}
+ENV NITRO_PRESET=bun
 RUN bun run build
 
 # copy production dependencies and source code into final image

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ COPY . .
 
 # [optional] tests & build
 ENV NODE_ENV=production
+ARG VITE_APP_NAME
+ENV VITE_APP_NAME=${VITE_APP_NAME}
 RUN bun run build
 
 # copy production dependencies and source code into final image


### PR DESCRIPTION
## Description

Support build-time configuration and optimization for Bun deployments using Dockerfile on Railway, Zeabur, and Koyeb.

**Links:**

* Render: https://pgt-4-pelari-kalcer.onrender.com/
* Railway: https://pgt-4-pelari-kalcer-production.up.railway.app/
* Zeabur: https://pgt-4-pelari-kalcer.zeabur.app/
* Koyeb: https://burning-sheelah-elingp-26145ab1.koyeb.app/

## Issue

Closes n/a

## Testing

- [x] `bun run check`
- [ ] `bun run db:reset` _(when schema or seeds change)_
- [x] `bun run build` _(optional, recommended when build/config tooling changes)_

## Checklist

- [x] Code is up-to-date with the `main` branch
- [x] Commit messages follow Conventional Commits
- [ ] Screenshots or notes included for visual changes
- [ ] Documentation and `.env.example` updated when required
- [ ] Schema changes include migration via `bun run db:generate` _(see [DATABASE.md](docs/DATABASE.md))_